### PR TITLE
Add onDragStart callback

### DIFF
--- a/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableLazyGridState.kt
+++ b/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableLazyGridState.kt
@@ -34,6 +34,7 @@ fun rememberReorderableLazyGridState(
     onMove: (ItemPosition, ItemPosition) -> Unit,
     gridState: LazyGridState = rememberLazyGridState(),
     canDragOver: ((draggedOver: ItemPosition, dragging: ItemPosition) -> Boolean)? = null,
+    onDragStart: ((startIndex: Int, x: Int, y: Int) -> (Unit))? = null,
     onDragEnd: ((startIndex: Int, endIndex: Int) -> (Unit))? = null,
     maxScrollPerFrame: Dp = 20.dp,
     dragCancelledAnimation: DragCancelledAnimation = SpringDragCancelledAnimation()
@@ -41,7 +42,7 @@ fun rememberReorderableLazyGridState(
     val maxScroll = with(LocalDensity.current) { maxScrollPerFrame.toPx() }
     val scope = rememberCoroutineScope()
     val state = remember(gridState) {
-        ReorderableLazyGridState(gridState, scope, maxScroll, onMove, canDragOver, onDragEnd, dragCancelledAnimation)
+        ReorderableLazyGridState(gridState, scope, maxScroll, onMove, canDragOver, onDragStart, onDragEnd, dragCancelledAnimation)
     }
     LaunchedEffect(state) {
         state.visibleItemsChanged()
@@ -63,9 +64,10 @@ class ReorderableLazyGridState(
     maxScrollPerFrame: Float,
     onMove: (fromIndex: ItemPosition, toIndex: ItemPosition) -> (Unit),
     canDragOver: ((draggedOver: ItemPosition, dragging: ItemPosition) -> Boolean)? = null,
+    onDragStart: ((startIndex: Int, x: Int, y: Int) -> (Unit))? = null,
     onDragEnd: ((startIndex: Int, endIndex: Int) -> (Unit))? = null,
     dragCancelledAnimation: DragCancelledAnimation = SpringDragCancelledAnimation()
-) : ReorderableState<LazyGridItemInfo>(scope, maxScrollPerFrame, onMove, canDragOver, onDragEnd, dragCancelledAnimation) {
+) : ReorderableState<LazyGridItemInfo>(scope, maxScrollPerFrame, onMove, canDragOver, onDragStart, onDragEnd, dragCancelledAnimation) {
     override val isVerticalScroll: Boolean
         get() = gridState.layoutInfo.orientation == Orientation.Vertical
     override val LazyGridItemInfo.left: Int

--- a/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableLazyListState.kt
+++ b/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableLazyListState.kt
@@ -38,6 +38,7 @@ fun rememberReorderableLazyListState(
     onMove: (ItemPosition, ItemPosition) -> Unit,
     listState: LazyListState = rememberLazyListState(),
     canDragOver: ((draggedOver: ItemPosition, dragging: ItemPosition) -> Boolean)? = null,
+    onDragStart: ((startIndex: Int, x: Int, y: Int) -> (Unit))? = null,
     onDragEnd: ((startIndex: Int, endIndex: Int) -> (Unit))? = null,
     maxScrollPerFrame: Dp = 20.dp,
     dragCancelledAnimation: DragCancelledAnimation = SpringDragCancelledAnimation()
@@ -45,7 +46,7 @@ fun rememberReorderableLazyListState(
     val maxScroll = with(LocalDensity.current) { maxScrollPerFrame.toPx() }
     val scope = rememberCoroutineScope()
     val state = remember(listState) {
-        ReorderableLazyListState(listState, scope, maxScroll, onMove, canDragOver, onDragEnd, dragCancelledAnimation)
+        ReorderableLazyListState(listState, scope, maxScroll, onMove, canDragOver, onDragStart, onDragEnd, dragCancelledAnimation)
     }
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
     LaunchedEffect(state) {
@@ -73,6 +74,7 @@ class ReorderableLazyListState(
     maxScrollPerFrame: Float,
     onMove: (fromIndex: ItemPosition, toIndex: ItemPosition) -> (Unit),
     canDragOver: ((draggedOver: ItemPosition, dragging: ItemPosition) -> Boolean)? = null,
+    onDragStart: ((startIndex: Int, x: Int, y: Int) -> (Unit))? = null,
     onDragEnd: ((startIndex: Int, endIndex: Int) -> (Unit))? = null,
     dragCancelledAnimation: DragCancelledAnimation = SpringDragCancelledAnimation()
 ) : ReorderableState<LazyListItemInfo>(
@@ -80,6 +82,7 @@ class ReorderableLazyListState(
     maxScrollPerFrame,
     onMove,
     canDragOver,
+    onDragStart,
     onDragEnd,
     dragCancelledAnimation
 ) {

--- a/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableState.kt
+++ b/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableState.kt
@@ -41,6 +41,7 @@ abstract class ReorderableState<T>(
     private val maxScrollPerFrame: Float,
     private val onMove: (fromIndex: ItemPosition, toIndex: ItemPosition) -> (Unit),
     private val canDragOver: ((draggedOver: ItemPosition, dragging: ItemPosition) -> Boolean)?,
+    private val onDragStart: ((startIndex: Int, x: Int, y: Int) -> (Unit))? = null,
     private val onDragEnd: ((startIndex: Int, endIndex: Int) -> (Unit))?,
     val dragCancelledAnimation: DragCancelledAnimation
 ) {
@@ -105,6 +106,7 @@ abstract class ReorderableState<T>(
             ?.also {
                 selected = it
                 draggingItemIndex = it.itemIndex
+                onDragStart?.invoke(it.itemIndex, offsetX, offsetY)
             } != null
     }
 


### PR DESCRIPTION
I needed a way to handle long press events for items in a reorderable list with detectReorderAfterLongPress, but using the combinedClickable modifier didn't worked in combination with the event management of ComposeReorderable.

The solution I found was to detect the onDragStart event, but it was not available in the API (unlike the onDragEnd event).

This PR was copied from https://github.com/aclassen/ComposeReorderable/pull/277